### PR TITLE
Switch AWS Nuke to ekristen fork

### DIFF
--- a/terraform/modules/nuke_pipeline/codebuild.tf
+++ b/terraform/modules/nuke_pipeline/codebuild.tf
@@ -17,7 +17,7 @@ resource "aws_codebuild_project" "aws_nuke" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "quay.io/rebuy/aws-nuke:latest"
+    image                       = "ghcr.io/ekristen/aws-nuke:v3.51.1"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
   }


### PR DESCRIPTION
The original version is no longer updated, and has been archived as of 2024-10-15

This new fork is the recommended replacement.

> [!WARNING]
> A review of compatibility of this new version should be performed before merging.

- [ ] Is the licence still acceptable?
- [ ] Has there been any breaking changes?
- [ ] What is the community consensus on this fork?
- [ ] The current image is using "latest", but there doesn't appear to be an equivalent for the `ekristen` fork.
- [ ] Perform a Dry-Run test of this change within our account, identifying what resources will now be destroyed.