### PR TITLE
Add exclusion for OIDC provider based on tags

### DIFF
--- a/aws-nuke.yaml
+++ b/aws-nuke.yaml
@@ -136,7 +136,10 @@ accounts:
         - type: glob
           value: "AWSServiceRole*"
         - "AWSReservedSSO_SandboxAdmin_772511f048f85463 -> AdministratorAccess"
-        - "codebuild-sandbox-nuke -> AdministratorAccess"      
+        - "codebuild-sandbox-nuke -> AdministratorAccess"
+      IAMOpenIDConnectProvider:
+        - property: "tag:ProtectFromNuke"
+          value: "true" 
   "612473995106": # devops pairing
     presets:
         - "controltower"


### PR DESCRIPTION
GitHub actions has an OIDC provider url, which is unique to the provider. 
We should have a long-lived identity provider for GitHub actions, which can be used by the team when they want to assume a role using that principal (and with appropriate trust policy and permission policy in place). Each person can't be responsible for creating the provider, because it can only exist once. 