### PR TITLE
Add persistent MSP Engineer interview resources to aws-nuke filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains the config to periodically clean the AWS Sandbox account of a
 resources using `aws-nuke`. It also contains the Terraform to deploy the AWS resources
 required to run this job remotely.
 
-It is possible to exlude resources you wish to retain by adding them to the `aws-nuke.yaml` config file.
+It is possible to exclude resources you wish to retain by adding them to the `aws-nuke.yaml` config file.
 
 ## Repo Structure
 - aws-nuke.yaml config file is used by [aws-nuke](https://github.com/rebuy-de/aws-nuke#readme)
@@ -18,8 +18,8 @@ It is possible to exlude resources you wish to retain by adding them to the `aws
 
 Test locally after updating aws-nuke.yaml
 
-```
-aws-vault exec madesso -- aws-nuke -c aws-nuke.yaml -q --force
+```shell
+aws-vault exec madesso -- aws-nuke run -c aws-nuke.yaml -q --force
 ```
 
 By default `aws-nuke` runs in dry-run mode. To really delete things add the `--no-dry-run` flag.

--- a/aws-nuke.yaml
+++ b/aws-nuke.yaml
@@ -132,14 +132,20 @@ accounts:
         - "ddb-scheduler-dev"
       EC2Instance:
         - "i-0789d3d84bf69c27b"
+      ECRRepository:
+        - "msp-highlow-*" # msp-support-engineer-interview
+      IAMOpenIDConnectProvider:
+        - property: "tag:ProtectFromNuke"
+          value: "true"
       IAMRolePolicyAttachment:
         - type: glob
           value: "AWSServiceRole*"
         - "AWSReservedSSO_SandboxAdmin_772511f048f85463 -> AdministratorAccess"
         - "codebuild-sandbox-nuke -> AdministratorAccess"
-      IAMOpenIDConnectProvider:
-        - property: "tag:ProtectFromNuke"
-          value: "true" 
+      KMSKey:
+        - "b2f7a236-7058-4604-88f5-90e9182471c8" # msp-support-engineer-interview
+      S3Bucket:
+        - "msp-support-engineer-interview-terraform-state" # msp-support-engineer-interview
   "612473995106": # devops pairing
     presets:
         - "controltower"


### PR DESCRIPTION
Because we don't want to keep having to recreate these parts for the interviews.