### PR TITLE
Exclude S3 buckets and KMS keys from the MSP interview "shared" stack

### DIFF
--- a/aws-nuke.yaml
+++ b/aws-nuke.yaml
@@ -70,9 +70,13 @@ presets:
       KMSKey:
         - property: "tag:MSPSupportEngineerInterviewStack"
           value: "bootstrap"
+        - property: "tag:MSPSupportEngineerInterviewStack"
+          value: "shared"
       S3Bucket:
         - property: "tag:MSPSupportEngineerInterviewStack"
           value: "bootstrap"
+        - property: "tag:MSPSupportEngineerInterviewStack"
+          value: "shared"
   cloud-interview-non-ephemeral-resources:
     filters:
       S3Bucket:


### PR DESCRIPTION
This is to keep the resources for the log file for the scripting exercise, added in this commit https://github.com/madetech/msp-support-engineer-interview/commit/8e78498c41fd695198d3d17795dadd2b82cb9213#diff-12c2d639a15a3dcc82199de70945705c606d8236373c2fa34699413174f1af85R31

The log file is used in every managed service engineer interview, the log file is only 10KiB so is essentially free, and the only real cost is $5/month for the KMS key